### PR TITLE
Disable benefitiaries address

### DIFF
--- a/inc/templates/altas/semanales.php
+++ b/inc/templates/altas/semanales.php
@@ -89,10 +89,10 @@
                     <th scope="col" class="d-none">Telefono</th>
                     <th scope="col" class="d-none">Nombre beneficiario 1</th>
                     <th scope="col" class="d-none">Teléfono beneficiario 1</th>
-                    <th scope="col" class="d-none">Domicilio beneficiario 1</th>
+                    <!--<th scope="col" class="d-none">Domicilio beneficiario 1</th> -->
                     <th scope="col" class="d-none">Nombre beneficiario 2</th>
                     <th scope="col" class="d-none">Teléfono beneficiario 2</th>
-                    <th scope="col" class="d-none">Domicilio beneficiario 2</th>
+                    <!--<th scope="col" class="d-none">Domicilio beneficiario 2</th>-->
                 </tr>
             </thead>
             <tbody id="dataTable">

--- a/inc/templates/empleados/modificar.php
+++ b/inc/templates/empleados/modificar.php
@@ -392,6 +392,7 @@
                     <div class="form-group col-md-6">
                         <label for="txtTelefonoB1">Teléfono</label>
                         <input type="text" class="form-control" id="txtTelefonoB1" name="txtTelefonoB1" maxlength="10">
+                        <input type="hidden" id="txtIdB1" name="txtIdB2"> 
                     </div>
                     <!-- COMENTADO <div class="form-group col-md-4">
                         <label for="txtCalleB1">Calle</label>
@@ -446,6 +447,7 @@
                         <div class="form-group col-md-6">
                             <label for="txtTelefonoB2">Teléfono</label>
                             <input type="text" class="form-control" id="txtTelefonoB2" name="txtTelefonoB2" maxlength="10">
+                            <input type="hidden" id="txtIdB2" name="txtIdB2"> 
                         </div>
                         <!-- COMENTADO <div class="form-group col-md-4">
                             <label for="txtCalleB2">Calle</label>
@@ -485,7 +487,6 @@
                         <div class="form-group col-md-8">
                             <label for="txtFraccionamientoB2">Colonia / Fraccionamiento</label>
                             <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select>
-                            <input type="hidden" id="txtIdB2" name="txtIdB2"> 
                         </div>
                     </div> -->
                 </div>

--- a/inc/templates/empleados/modificar.php
+++ b/inc/templates/empleados/modificar.php
@@ -385,15 +385,15 @@
                 <h2>Beneficiarios</h2>
                 <h4 class="mt-3">Beneficiario 1</h4>
                 <div class="form-row">
-                    <div class="form-group col-md-4">
+                    <div class="form-group col-md-6">
                         <label for="txtNombreB1">Nombre completo</label>
                         <input type="text" class="form-control" id="txtNombreB1" name="txtNombreB1">
                     </div>
-                    <div class="form-group col-md-4">
+                    <div class="form-group col-md-6">
                         <label for="txtTelefonoB1">Teléfono</label>
                         <input type="text" class="form-control" id="txtTelefonoB1" name="txtTelefonoB1" maxlength="10">
                     </div>
-                    <div class="form-group col-md-4">
+                    <!-- COMENTADO <div class="form-group col-md-4">
                         <label for="txtCalleB1">Calle</label>
                         <input type="text" class="form-control" id="txtCalleB1" name="txtCalleB1">
                     </div>
@@ -433,21 +433,21 @@
                         <label for="txtFraccionamientoB1">Colonia / Fraccionamiento</label>
                         <select class="form-control" id="txtFraccionamientoB1" name="txtFraccionamientoB1"></select> 
                         <input type="hidden" id="txtIdB1" name="txtIdB1"> 
-                    </div>
-                </div>
+                    </div> --> 
+                </div> 
 
                 <div id="beneficiario2Container">
                     <h4 class="mt-4">Beneficiario 2</h4>
                     <div class="form-row">
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-6">
                             <label for="txtNombreB2">Nombre completo</label>
                             <input type="text" class="form-control" id="txtNombreB2" name="txtNombreB2">
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group col-md-6">
                             <label for="txtTelefonoB2">Teléfono</label>
                             <input type="text" class="form-control" id="txtTelefonoB2" name="txtTelefonoB2" maxlength="10">
                         </div>
-                        <div class="form-group col-md-4">
+                        <!-- COMENTADO <div class="form-group col-md-4">
                             <label for="txtCalleB2">Calle</label>
                             <input type="text" class="form-control" id="txtCalleB2" name="txtCalleB2">
                         </div>
@@ -487,7 +487,7 @@
                             <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select>
                             <input type="hidden" id="txtIdB2" name="txtIdB2"> 
                         </div>
-                    </div>
+                    </div> -->
                 </div>
             </div>
             <hr>

--- a/inc/templates/empleados/nuevo.php
+++ b/inc/templates/empleados/nuevo.php
@@ -376,15 +376,15 @@
     <h2>Beneficiarios</h2>
     <h4 class="mt-3">Beneficiario 1</h4>
     <div class="form-row">
-        <div class="form-group col-md-4">
+        <div class="form-group col-md-6">
             <label for="txtNombreB1">Nombre completo</label>
             <input type="text" class="form-control" id="txtNombreB1" name="txtNombreB1">
         </div>
-        <div class="form-group col-md-4">
+        <div class="form-group col-md-6">
             <label for="txtTelefonoB1">Teléfono</label>
             <input type="text" class="form-control" id="txtTelefonoB1" name="txtTelefonoB1" maxlength="10">
         </div>
-        <div class="form-group col-md-4">
+        <!-- COMENTADO <div class="form-group col-md-4">
             <label for="txtCalleB1">Calle</label>
             <input type="text" class="form-control" id="txtCalleB1" name="txtCalleB1">
         </div>
@@ -416,28 +416,28 @@
         <div class="form-group col-md-4">
             <label for="txtLocalidadB1">Localidad</label>
             <input type="text" class="form-control" id="txtLocalidadB1" name="txtLocalidadB1">
-        </div>
+        </div> 
     </div>
 
     <div class="form-row">
         <div class="form-group col-md-8">
             <label for="txtFraccionamientoB1">Colonia / Fraccionamiento</label>
             <select class="form-control" id="txtFraccionamientoB1" name="txtFraccionamientoB1"></select> 
-        </div>
-    </div>
+        </div> --> 
+    </div> 
 
     <div id="beneficiario2Container">
         <h4 class="mt-4">Beneficiario 2</h4>
         <div class="form-row">
-            <div class="form-group col-md-4">
+            <div class="form-group col-md-6">
                 <label for="txtNombreB2">Nombre completo</label>
                 <input type="text" class="form-control" id="txtNombreB2" name="txtNombreB2">
             </div>
-            <div class="form-group col-md-4">
+            <div class="form-group col-md-6">
                 <label for="txtTelefonoB2">Teléfono</label>
                 <input type="text" class="form-control" id="txtTelefonoB2" name="txtTelefonoB2" maxlength="10">
             </div>
-            <div class="form-group col-md-4">
+            <!-- COMENTADO <div class="form-group col-md-4">
                 <label for="txtCalleB2">Calle</label>
                 <input type="text" class="form-control" id="txtCalleB2" name="txtCalleB2">
             </div>
@@ -476,7 +476,7 @@
                 <label for="txtFraccionamientoB2">Colonia / Fraccionamiento</label>
                 <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select> 
             </div>
-        </div>
+        </div> -->
     </div>
 </div>
       <hr>

--- a/inc/templates/empleados/reingreso.php
+++ b/inc/templates/empleados/reingreso.php
@@ -393,6 +393,7 @@
         <div class="form-group col-md-6">
             <label for="txtTelefonoB1">Teléfono</label>
             <input type="text" class="form-control" id="txtTelefonoB1" name="txtTelefonoB1" maxlength="10">
+            <input type="hidden" id="txtIdB1" name="txtIdB1">
         </div>
         <!-- COMENTADO <div class="form-group col-md-4">
             <label for="txtCalleB1">Calle</label>
@@ -433,7 +434,6 @@
         <div class="form-group col-md-8">
             <label for="txtFraccionamientoB1">Colonia / Fraccionamiento</label>
             <select class="form-control" id="txtFraccionamientoB1" name="txtFraccionamientoB1"></select>
-            <input type="hidden" id="txtIdB1" name="txtIdB1">  
         </div> -->
     </div> 
 
@@ -447,6 +447,7 @@
             <div class="form-group col-md-6">
                 <label for="txtTelefonoB2">Teléfono</label>
                 <input type="text" class="form-control" id="txtTelefonoB2" name="txtTelefonoB2" maxlength="10">
+                <input type="hidden" id="txtIdB2" name="txtIdB2"> 
             </div>
             <!-- COMENTADO <div class="form-group col-md-4">
                 <label for="txtCalleB2">Calle</label>
@@ -485,8 +486,7 @@
         <div class="form-row">
             <div class="form-group col-md-8">
                 <label for="txtFraccionamientoB2">Colonia / Fraccionamiento</label>
-                <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select>
-                <input type="hidden" id="txtIdB2" name="txtIdB2">  
+                <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select> 
             </div>
         </div> -->
     </div>

--- a/inc/templates/empleados/reingreso.php
+++ b/inc/templates/empleados/reingreso.php
@@ -386,15 +386,15 @@
     <h2>Beneficiarios</h2>
     <h4 class="mt-3">Beneficiario 1</h4>
     <div class="form-row">
-        <div class="form-group col-md-4">
+        <div class="form-group col-md-6">
             <label for="txtNombreB1">Nombre completo</label>
             <input type="text" class="form-control" id="txtNombreB1" name="txtNombreB1">
         </div>
-        <div class="form-group col-md-4">
+        <div class="form-group col-md-6">
             <label for="txtTelefonoB1">Teléfono</label>
             <input type="text" class="form-control" id="txtTelefonoB1" name="txtTelefonoB1" maxlength="10">
         </div>
-        <div class="form-group col-md-4">
+        <!-- COMENTADO <div class="form-group col-md-4">
             <label for="txtCalleB1">Calle</label>
             <input type="text" class="form-control" id="txtCalleB1" name="txtCalleB1">
         </div>
@@ -434,21 +434,21 @@
             <label for="txtFraccionamientoB1">Colonia / Fraccionamiento</label>
             <select class="form-control" id="txtFraccionamientoB1" name="txtFraccionamientoB1"></select>
             <input type="hidden" id="txtIdB1" name="txtIdB1">  
-        </div>
-    </div>
+        </div> -->
+    </div> 
 
     <div id="beneficiario2Container">
         <h4 class="mt-4">Beneficiario 2</h4>
         <div class="form-row">
-            <div class="form-group col-md-4">
+            <div class="form-group col-md-6">
                 <label for="txtNombreB2">Nombre completo</label>
                 <input type="text" class="form-control" id="txtNombreB2" name="txtNombreB2">
             </div>
-            <div class="form-group col-md-4">
+            <div class="form-group col-md-6">
                 <label for="txtTelefonoB2">Teléfono</label>
                 <input type="text" class="form-control" id="txtTelefonoB2" name="txtTelefonoB2" maxlength="10">
             </div>
-            <div class="form-group col-md-4">
+            <!-- COMENTADO <div class="form-group col-md-4">
                 <label for="txtCalleB2">Calle</label>
                 <input type="text" class="form-control" id="txtCalleB2" name="txtCalleB2">
             </div>
@@ -488,7 +488,7 @@
                 <select class="form-control" id="txtFraccionamientoB2" name="txtFraccionamientoB2"></select>
                 <input type="hidden" id="txtIdB2" name="txtIdB2">  
             </div>
-        </div>
+        </div> -->
     </div>
 </div>
             <hr>

--- a/js/control.js
+++ b/js/control.js
@@ -375,6 +375,7 @@ $(document).ready(function () {
                 $("#txtCelular").val(datos.celular);
                 $("#txtContacto").val(datos.contacto_emergencia_nombre);
                 $("#txtNcontacto").val(datos.contacto_emergencia_numero);
+                $("#txtIdB1").val(datos.id_beneficiario1);
                 $("#txtNombreB1").val(datos.nombre_beneficiario1);
                 $("#txtTelefonoB1").val(datos.telefono_beneficiario1);
                 /*$("#txtCalleB1").val(datos.calle_b1);
@@ -385,6 +386,7 @@ $(document).ready(function () {
                 $("#txtMunicipioB1").val(datos.municipio_b1);
                 $("#txtEstadoB1").val(datos.estado_b1);
                 $("#txtLocalidadB1").val(datos.localidad_b1);*/
+                $("#txtIdB2").val(datos.id_beneficiario2);
                 $("#txtNombreB2").val(datos.nombre_beneficiario2);
                 $("#txtTelefonoB2").val(datos.telefono_beneficiario2);
                 /*$("#txtCalleB2").val(datos.calle_b2);

--- a/js/control.js
+++ b/js/control.js
@@ -580,7 +580,7 @@ $(document).ready(function () {
     }
 
     let listarFraccionamientos = (cp) => {
-    if (cp.length === 5) {
+    if (cp?.length === 5) {
         $.ajax({
             type: "GET",
             url: `https://api.copomex.com/query/info_cp/${cp}?type=simplified&token=e5ecaba1-8182-4a09-80fd-dbd5781e7e3d`,
@@ -615,7 +615,7 @@ $(document).ready(function () {
 };
 
     /*let llenarBeneficiarios1 = (cp) => {
-    if (cp.length === 5) {
+    if (cp?.$length === 5) {
         $.ajax({
             type: "GET",
             url: `https://api.copomex.com/query/info_cp/${cp}?type=simplified&token=e5ecaba1-8182-4a09-80fd-dbd5781e7e3d`,
@@ -650,7 +650,7 @@ $(document).ready(function () {
 };
 
 let llenarBeneficiarios2 = (cp) => {
-    if (cp.length === 5) {
+    if (cp?.length === 5) {
         $.ajax({
             type: "GET",
             url: `https://api.copomex.com/query/info_cp/${cp}?type=simplified&token=e5ecaba1-8182-4a09-80fd-dbd5781e7e3d`,

--- a/js/control.js
+++ b/js/control.js
@@ -377,24 +377,24 @@ $(document).ready(function () {
                 $("#txtNcontacto").val(datos.contacto_emergencia_numero);
                 $("#txtNombreB1").val(datos.nombre_beneficiario1);
                 $("#txtTelefonoB1").val(datos.telefono_beneficiario1);
-                $("#txtCalleB1").val(datos.calle_b1);
+                /*$("#txtCalleB1").val(datos.calle_b1);
                 $("#txtNumeroExteriorB1").val(datos.numero_exterior_b1);
                 $("#txtNumeroInteriorB1").val(datos.numero_interior_b1);
                 llenarBeneficiarios1(datos.codigo_postal_b1)
                 $("#txtCodigoPostalB1").val(datos.codigo_postal_b1);
                 $("#txtMunicipioB1").val(datos.municipio_b1);
                 $("#txtEstadoB1").val(datos.estado_b1);
-                $("#txtLocalidadB1").val(datos.localidad_b1);
+                $("#txtLocalidadB1").val(datos.localidad_b1);*/
                 $("#txtNombreB2").val(datos.nombre_beneficiario2);
                 $("#txtTelefonoB2").val(datos.telefono_beneficiario2);
-                $("#txtCalleB2").val(datos.calle_b2);
+                /*$("#txtCalleB2").val(datos.calle_b2);
                 $("#txtNumeroExteriorB2").val(datos.numero_exterior_b2);
                 $("#txtNumeroInteriorB2").val(datos.numero_interior_b2);
                 llenarBeneficiarios2(datos.codigo_postal_b1)
                 $("#txtCodigoPostalB2").val(datos.codigo_postal_b2);
                 $("#txtMunicipioB2").val(datos.municipio_b2);
                 $("#txtEstadoB2").val(datos.estado_b2);
-                $("#txtLocalidadB2").val(datos.localidad_b2);
+                $("#txtLocalidadB2").val(datos.localidad_b2);*/
 
                 setTimeout(function () {
                     $("#txtSucursal").val(datos.id_sucursal);
@@ -413,10 +413,10 @@ $(document).ready(function () {
                     $("#txtFraccionamiento").val(datos.fraccionamiento.toUpperCase());
                 }, 1000);
 
-                setTimeout(function () {
+                /*setTimeout(function () {
                     $("#txtFraccionamientoB1").val(datos.fraccionamiento_b1.toUpperCase());
                     $("#txtFraccionamientoB2").val(datos.fraccionamiento_b2.toUpperCase());
-                }, 1000); 
+                }, 1000); */
 
                 $("#txtClasificacion").focusout(function () {
                     listarDepartamentos($("#txtSucursal").val(), $("#txtClasificacion").val());
@@ -430,13 +430,13 @@ $(document).ready(function () {
                     listarFraccionamientos($("#txtCP").val());
                 });
 
-                $("#txtCodigoPostalB1").focusout(function () {
+                /*$("#txtCodigoPostalB1").focusout(function () {
                     llenarBeneficiarios1($("#txtCodigoPostalB1").val());
                 });
 
                 $("#txtCodigoPostalB2").focusout(function () {
                     llenarBeneficiarios2($("#txtCodigoPostalB2").val());
-                }); 
+                }); */
 
                 $("#txtClasificacion").focusout(function () {
                     listarJefes($("#txtClasificacion").val());
@@ -612,7 +612,7 @@ $(document).ready(function () {
     }
 };
 
-    let llenarBeneficiarios1 = (cp) => {
+    /*let llenarBeneficiarios1 = (cp) => {
     if (cp.length === 5) {
         $.ajax({
             type: "GET",
@@ -680,14 +680,14 @@ let llenarBeneficiarios2 = (cp) => {
             timer: 1000
         });
     }
-};
+}; 
 $('#txtCodigoPostalB1').on('blur', function() {
     llenarBeneficiarios1($(this).val());
 });
 
 $('#txtCodigoPostalB2').on('blur', function() {
     llenarBeneficiarios2($(this).val());
-}); 
+}); */
 
     $("#exportInfo").click(function () {
         var action = 'json-empleados';
@@ -1886,10 +1886,10 @@ $('#txtCodigoPostalB2').on('blur', function() {
                 row.append($("<td class='d-none'>" + rowInfo.telefono + " </td>"));
                 row.append($("<td class='d-none'>" + rowInfo.nombre_beneficiario1  + " </td>"));
                 row.append($("<td class='d-none'>" + rowInfo.telefono_beneficiario1 + " </td>"));
-                row.append($("<td class='d-none'>" + rowInfo.domicilio_beneficiario1 + " </td>"));
+                //row.append($("<td class='d-none'>" + rowInfo.domicilio_beneficiario1 + " </td>"));
                 row.append($("<td class='d-none'>" + rowInfo.nombre_beneficiario2 + " </td>"));
                 row.append($("<td class='d-none'>" + rowInfo.telefono_beneficiario2 + " </td>"));
-                row.append($("<td class='d-none'>" + rowInfo.domicilio_beneficiario2 + " </td>"));
+                //row.append($("<td class='d-none'>" + rowInfo.domicilio_beneficiario2 + " </td>"));
             }
 
             break;
@@ -3057,25 +3057,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     $("#txtIdB1").val(datos.id_beneficiario1);
                     $("#txtNombreB1").val(datos.nombre_beneficiario1);
                     $("#txtTelefonoB1").val(datos.telefono_beneficiario1);
-                    $("#txtCalleB1").val(datos.calle_b1);
+                    /*$("#txtCalleB1").val(datos.calle_b1);
                     $("#txtNumeroExteriorB1").val(datos.numero_exterior_b1);
                     $("#txtNumeroInteriorB1").val(datos.numero_interior_b1);
                     llenarBeneficiarios1(datos.codigo_postal_b1)
                     $("#txtCodigoPostalB1").val(datos.codigo_postal_b1);
                     $("#txtMunicipioB1").val(datos.municipio_b1);
                     $("#txtEstadoB1").val(datos.estado_b1);
-                    $("#txtLocalidadB1").val(datos.localidad_b1);
-                    $("#txtIdB2").val(datos.id_beneficiario2);
+                    $("#txtLocalidadB1").val(datos.localidad_b1); */
+                    $("#txtIdB2").val(datos.id_beneficiario2); 
                     $("#txtNombreB2").val(datos.nombre_beneficiario2);
                     $("#txtTelefonoB2").val(datos.telefono_beneficiario2);
-                    $("#txtCalleB2").val(datos.calle_b2);
+                    /*$("#txtCalleB2").val(datos.calle_b2);
                     $("#txtNumeroExteriorB2").val(datos.numero_exterior_b2);
                     $("#txtNumeroInteriorB2").val(datos.numero_interior_b2);
                     llenarBeneficiarios2(datos.codigo_postal_b2)
                     $("#txtCodigoPostalB2").val(datos.codigo_postal_b2);
                     $("#txtMunicipioB2").val(datos.municipio_b2);
                     $("#txtEstadoB2").val(datos.estado_b2);
-                    $("#txtLocalidadB2").val(datos.localidad_b2);
+                    $("#txtLocalidadB2").val(datos.localidad_b2);*/
 
 
                     setTimeout(function () {
@@ -3096,10 +3096,10 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         $("#txtFraccionamiento").val(datos.fraccionamiento.toUpperCase());
                     }, 1000);
 
-                    setTimeout(function () {
+                    /*setTimeout(function () {
                         $("#txtFraccionamientoB1").val(datos.fraccionamiento_b1.toUpperCase());
                         $("#txtFraccionamientoB2").val(datos.fraccionamiento_b2.toUpperCase());
-                    }, 1000); 
+                    }, 1000); */
 
 
                 }
@@ -3110,13 +3110,13 @@ $('#txtCodigoPostalB2').on('blur', function() {
                 listarFraccionamientos($("#txtCP").val());
             });
 
-            $("#txtCodigoPostalB1").focusout(function () {
+            /*$("#txtCodigoPostalB1").focusout(function () {
                 llenarBeneficiarios1($("#txtCodigoPostalB1").val());
             });
 
             $("#txtCodigoPostalB2").focusout(function () {
                 llenarBeneficiarios2($("#txtCodigoPostalB2").val()); 
-            });
+            }); */
 
             $("#txtClasificacion").focusout(function () {
                 listarDepartamentos($("#txtSucursal").val(), $("#txtClasificacion").val());
@@ -3193,25 +3193,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     idB1 = $('#txtIdB1').val(),
                     nombreB1 = $('#txtNombreB1').val(),
                     telefonoB1 = $('#txtTelefonoB1').val(),
-                    calleB1 = $('#txtCalleB1').val(),
+                    /*calleB1 = $('#txtCalleB1').val(),
                     numeroExteriorB1 = $('#txtNumeroExteriorB1').val(),
                     numeroInteriorB1 = $('#txtNumeroInteriorB1').val(),
                     codigoPostalB1 = $('#txtCodigoPostalB1').val(),
                     estadoB1 = $('#txtEstadoB1').val(),
                     municipioB1 = $('#txtMunicipioB1').val(),
                     localidadB1 = $('#txtLocalidadB1').val(),
-                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(),
+                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(),*/
                     idB2 = $('#txtIdB2').val(),
                     nombreB2 = $('#txtNombreB2').val(),
-                    telefonoB2 = $('#txtTelefonoB2').val(),
-                    calleB2 = $('#txtCalleB2').val(),
+                    telefonoB2 = $('#txtTelefonoB2').val();
+                    /*calleB2 = $('#txtCalleB2').val(),
                     numeroExteriorB2 = $('#txtNumeroExteriorB2').val(),
                     numeroInteriorB2 = $('#txtNumeroInteriorB2').val(),
                     codigoPostalB2 = $('#txtCodigoPostalB2').val(),
                     estadoB2 = $('#txtEstadoB2').val(),
                     municipioB2 = $('#txtMunicipioB2').val(),
                     localidadB2 = $('#txtLocalidadB2').val(),
-                    fraccionamientoB2 = $('#txtFraccionamientoB2').val();
+                    fraccionamientoB2 = $('#txtFraccionamientoB2').val(); */
                 domicilio = `${calle} #${numE} Int.${numI} ${fraccionamiento}`;
 
                 if(reclutado_por !== ''){
@@ -3445,7 +3445,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB1.trim() === "") {
+                /*if (calleB1.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -3520,7 +3520,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                }
+                } */
                 
                 if (nombreB2.trim() === "") {
                     Swal.fire({
@@ -3544,7 +3544,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB2.trim() === "") {
+                /*if (calleB2.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -3619,7 +3619,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                }
+                } */
                     var nombreLargo = `${aPaterno} ${aMaterno} ${nombre}`;
                     $.ajax({
                         type: 'POST',
@@ -3687,25 +3687,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                             idB1: idB1,
                             nombreB1: nombreB1,
                             telefonoB1: telefonoB1,
-                            calleB1: calleB1,
+                            /*calleB1: calleB1,
                             numeroExteriorB1: numeroExteriorB1,
                             numeroInteriorB1: numeroInteriorB1,
                             codigoPostalB1: codigoPostalB1,
                             estadoB1: estadoB1,
                             municipioB1: municipioB1,
                             localidadB1: localidadB1,
-                            fraccionamientoB1: fraccionamientoB1,
+                            fraccionamientoB1: fraccionamientoB1, */
                             idB2: idB2,
                             nombreB2: nombreB2,
-                            telefonoB2: telefonoB2,
-                            calleB2: calleB2,
+                            telefonoB2: telefonoB2
+                            /*calleB2: calleB2,
                             numeroExteriorB2: numeroExteriorB2,
                             numeroInteriorB2: numeroInteriorB2,
                             codigoPostalB2: codigoPostalB2,
                             estadoB2: estadoB2,
                             municipioB2: municipioB2,
                             localidadB2: localidadB2,
-                            fraccionamientoB2: fraccionamientoB2
+                            fraccionamientoB2: fraccionamientoB2 */
                         },
                         success: function (response) {
                             var respuesta = JSON.parse(response);
@@ -3973,7 +3973,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                 listarFraccionamientos(cp);
             });
 
-            $("#txtCodigoPostalB1").focusout(function () {
+            /*$("#txtCodigoPostalB1").focusout(function () {
                 var codigoPostalB1 = $('#txtCodigoPostalB1').val();
                 llenarBeneficiarios1(codigoPostalB1);
             });
@@ -3981,7 +3981,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
             $("#txtCodigoPostalB2").focusout(function () {
                 var codigoPostalB2 = $('#txtCodigoPostalB2').val();
                 llenarBeneficiarios2(codigoPostalB2);
-            }); 
+            }); */
 
             //Validar el puesto ingresado
             $('#txtPuesto').focusout(function () {
@@ -4114,25 +4114,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     idB1 = $('#txtIdB1').val(),
                     nombreB1 = $('#txtNombreB1').val(),
                     telefonoB1 = $('#txtTelefonoB1').val(),
-                    calleB1 = $('#txtCalleB1').val(),
+                    /*calleB1 = $('#txtCalleB1').val(),
                     numeroExteriorB1 = $('#txtNumeroExteriorB1').val(),
                     numeroInteriorB1 = $('#txtNumeroInteriorB1').val(),
                     codigoPostalB1 = $('#txtCodigoPostalB1').val(),
                     estadoB1 = $('#txtEstadoB1').val(),
                     municipioB1 = $('#txtMunicipioB1').val(),
                     localidadB1 = $('#txtLocalidadB1').val(),
-                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(),
+                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(), */
                     idB2 = $('#txtIdB2').val(),
                     nombreB2 = $('#txtNombreB2').val(),
                     telefonoB2 = $('#txtTelefonoB2').val(),
-                    calleB2 = $('#txtCalleB2').val(),
+                    /*calleB2 = $('#txtCalleB2').val(),
                     numeroExteriorB2 = $('#txtNumeroExteriorB2').val(),
                     numeroInteriorB2 = $('#txtNumeroInteriorB2').val(),
                     codigoPostalB2 = $('#txtCodigoPostalB2').val(),
                     estadoB2 = $('#txtEstadoB2').val(),
                     municipioB2 = $('#txtMunicipioB2').val(),
                     localidadB2 = $('#txtLocalidadB2').val(),
-                    fraccionamientoB2 = $('#txtFraccionamientoB2').val(),
+                    fraccionamientoB2 = $('#txtFraccionamientoB2').val(), */
 
                     curpini = curp.substr(0, 4),
                     curpfin = curp.substr(10, 8),
@@ -4372,7 +4372,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB1.trim() === "") {
+                /*if (calleB1.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -4447,7 +4447,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                }
+                } */
                 
                 if (nombreB2.trim() === "") {
                     Swal.fire({
@@ -4471,7 +4471,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB2.trim() === "") {
+                /*if (calleB2.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -4546,7 +4546,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                }
+                } */
                     var nombreLargo = `${aPaterno} ${aMaterno} ${nombre}`;
                     $.ajax({
                         type: 'POST',
@@ -4614,25 +4614,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                             idB1: idB1,
                             nombreB1: nombreB1,
                             telefonoB1: telefonoB1,
-                            calleB1: calleB1,
+                            /*calleB1: calleB1,
                             numeroExteriorB1: numeroExteriorB1,
                             numeroInteriorB1: numeroInteriorB1,
                             codigoPostalB1: codigoPostalB1,
                             estadoB1: estadoB1,
                             municipioB1: municipioB1,
                             localidadB1: localidadB1,
-                            fraccionamientoB1: fraccionamientoB1,
-                            idB2: idB2,
+                            fraccionamientoB1: fraccionamientoB1, */
+                            idB2: idB2, 
                             nombreB2: nombreB2,
-                            telefonoB2: telefonoB2,
-                            calleB2: calleB2,
+                            telefonoB2: telefonoB2
+                            /*calleB2: calleB2,
                             numeroExteriorB2: numeroExteriorB2,
                             numeroInteriorB2: numeroInteriorB2,
                             codigoPostalB2: codigoPostalB2,
                             estadoB2: estadoB2,
                             municipioB2: municipioB2,
                             localidadB2: localidadB2,
-                            fraccionamientoB2: fraccionamientoB2
+                            fraccionamientoB2: fraccionamientoB2 */
                         },
                         success: function (response) {
                             var respuesta = JSON.parse(response);
@@ -5012,7 +5012,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                 listarFraccionamientos(cp);
             });
 
-            $("#txtCodigoPostalB1").focusout(function () {
+            /*$("#txtCodigoPostalB1").focusout(function () {
                 var codigoPostalB1 = $('#txtCodigoPostalB1').val();
                 llenarBeneficiarios1(codigoPostalB1);
             });
@@ -5020,7 +5020,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
             $("#txtCodigoPostalB2").focusout(function () {
                 var codigoPostalB2 = $('#txtCodigoPostalB2').val();
                 llenarBeneficiarios2(codigoPostalB2);
-            }); 
+            }); */
 
 
             $("#txtPaterno").focusout(function () {
@@ -5180,24 +5180,25 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     //Datos de beneficiarios
                     nombreB1 = $('#txtNombreB1').val(),
                     telefonoB1 = $('#txtTelefonoB1').val(),
-                    calleB1 = $('#txtCalleB1').val(),
+                    /*calleB1 = $('#txtCalleB1').val(),
                     numeroExteriorB1 = $('#txtNumeroExteriorB1').val(),
                     numeroInteriorB1 = $('#txtNumeroInteriorB1').val(),
                     codigoPostalB1 = $('#txtCodigoPostalB1').val(),
                     estadoB1 = $('#txtEstadoB1').val(),
                     municipioB1 = $('#txtMunicipioB1').val(),
                     localidadB1 = $('#txtLocalidadB1').val(),
-                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(),
+                    fraccionamientoB1 = $('#txtFraccionamientoB1').val(), */
+                    
                     nombreB2 = $('#txtNombreB2').val(),
                     telefonoB2 = $('#txtTelefonoB2').val(),
-                    calleB2 = $('#txtCalleB2').val(),
+                    /*calleB2 = $('#txtCalleB2').val(),
                     numeroExteriorB2 = $('#txtNumeroExteriorB2').val(),
                     numeroInteriorB2 = $('#txtNumeroInteriorB2').val(),
                     codigoPostalB2 = $('#txtCodigoPostalB2').val(),
                     estadoB2 = $('#txtEstadoB2').val(),
                     municipioB2 = $('#txtMunicipioB2').val(),
                     localidadB2 = $('#txtLocalidadB2').val(),
-                    fraccionamientoB2 = $('#txtFraccionamientoB2').val(),
+                    fraccionamientoB2 = $('#txtFraccionamientoB2').val(),*/
 
                     curpini = curp.substr(0, 4),
                     curpfin = curp.substr(10, 8);
@@ -5457,7 +5458,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB1.trim() === "") {
+                /*if (calleB1.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -5532,7 +5533,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                }
+                } */
                 
                 if (nombreB2.trim() === "") {
                     Swal.fire({
@@ -5556,7 +5557,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                     return;
                 }
                 
-                if (calleB2.trim() === "") {
+                /*if (calleB2.trim() === "") {
                     Swal.fire({
                         position: 'center',
                         type: 'warning',
@@ -5631,7 +5632,7 @@ $('#txtCodigoPostalB2').on('blur', function() {
                         timer: 2000
                     });
                     return;
-                } 
+                } */
                     var nombreLargo = `${aPaterno} ${aMaterno} ${nombre}`;
                     $.ajax({
                         type: 'POST',
@@ -5697,24 +5698,24 @@ $('#txtCodigoPostalB2').on('blur', function() {
                             empleado_activo: empleado_activo,
                             nombreB1: nombreB1,
                             telefonoB1: telefonoB1,
-                            calleB1: calleB1,
+                            /*calleB1: calleB1,
                             numeroExteriorB1: numeroExteriorB1,
                             numeroInteriorB1: numeroInteriorB1,
                             fraccionamientoB1: fraccionamientoB1,
                             codigoPostalB1: codigoPostalB1,
                             estadoB1: estadoB1,
                             municipioB1: municipioB1,
-                            localidadB1: localidadB1,
+                            localidadB1: localidadB1, */
                             nombreB2: nombreB2,
-                            telefonoB2: telefonoB2,
-                            calleB2: calleB2,
+                            telefonoB2: telefonoB2
+                            /*calleB2: calleB2,
                             numeroExteriorB2: numeroExteriorB2,
                             numeroInteriorB2: numeroInteriorB2,
                             fraccionamientoB2: fraccionamientoB2,
                             codigoPostalB2: codigoPostalB2,
                             estadoB2: estadoB2,
                             municipioB2: municipioB2,
-                            localidadB2: localidadB2
+                            localidadB2: localidadB2*/
                         },
                         success: function (response) {
                             var respuesta = JSON.parse(response);


### PR DESCRIPTION
## What was done?
Disable benefitiaries address and correct benefitiaries duplicates.

## Why?
Human Resources Area requested the change.

### Major changes:
- fix(semanales.php, modificar.php, nuevo.php, reingreso.php, control.js): adjust form layouts and comment out address fields for beneficiaries.
- fix(beneficiary id): add hidden input and value.
- fix(control.js): add optional chaining to prevent errors when checking CP length.